### PR TITLE
Improved the PKGBUILD according to our standard

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,25 +1,24 @@
-# Maintainer: Matt C <matt[at]getcryst[dot]al>
+# Maintainer: echo -n 'bWF0dEBnZXRjcnlzdC5hbA==' | base64 -d
+# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA==' | base64 -d
 
 pkgname=jade
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Scriptable backend & TUI Installer for Crystal Linux"
-license=('GPLv3')
 arch=('x86_64')
-url="https://github.com/crystal-linux/$pkgname"
-license=('GPL')
-source=("jade-$pkgver-$pkgrel::git+$url#tag=v$pkgver")
-sha256sums=('SKIP')
+url="https://github.com/crystal-linux/${pkgname}"
+license=('GPL3')
 depends=('parted')
 makedepends=('cargo')
+source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('fcf1b168e14c0903572d45b9a16a241a2b72edf2f496745502c7edf24ba3ee62')
 
 build() {
-    cd "$srcdir/$pkgname-$pkgver-$pkgrel"
+    cd "${srcdir}/${pkgname}-${pkgver}"
     cargo build --release
 }
 
 package() {
-    mkdir -p $pkgdir/usr/bin
-    chmod +x ${srcdir}/$pkgname-$pkgver-$pkgrel/target/release/jade
-    install --mode +x ${srcdir}/$pkgname-$pkgver-$pkgrel/target/release/jade  $pkgdir/usr/bin/.
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    install -Dm 755 "target/release/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,7 +22,7 @@ build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
     export RUSTUP_TOOLCHAIN=stable
     export CARGO_TARGET_DIR=target
-    cargo build --frozen --release
+    cargo build --frozen --release --all-features
 }
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,9 +13,16 @@ makedepends=('cargo')
 source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('fcf1b168e14c0903572d45b9a16a241a2b72edf2f496745502c7edf24ba3ee62')
 
+prepare() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    cargo fetch --locked --target "${CARCH}-unknown-linux-gnu"
+}
+
 build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
-    cargo build --release
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release
 }
 
 package() {


### PR DESCRIPTION
Hi,

A round of improvements for the `jade` PKGBUILD:

- Switched all vars to the `${var}` format.
- Reordered the top vars to match the Arch PKGBUILD template order.
- Switch the `license` from `GPLv3` to `GPL3` (it has to be named that way).
- Deleted the extra `GPL` license (if there's multiple licenses, they have to both go into the same `license` array).
- Switched source from `git` to release's archive. Added the integrity check accordingly.
- Modified the `package ()` function to use `install` instead of `mkdir + chmod + install`.

What do you think?